### PR TITLE
fix errors caused by rggen/rggen-core update

### DIFF
--- a/lib/rggen/verilog/bit_field/type/w0crs_w0src_w1crs_w1src_wcrs_wsrc.rb
+++ b/lib/rggen/verilog/bit_field/type/w0crs_w0src_w1crs_w1src_wcrs_wsrc.rb
@@ -19,7 +19,7 @@ RgGen.define_list_item_feature(
     end
 
     def read_set?
-      [:w0crs, :w1crs, :wcrs].include?(bit_field.type)
+      [:w0crs, :w1crs, :wcrs].any? { |type| bit_field.type == type }
     end
 
     def write_action


### PR DESCRIPTION
This PR is to fix errors caused by rggen/rggen-core@4ec870fa6aa05c6c549e0434447f08549332a76b.

rggen/rggen#100
